### PR TITLE
Filter extraneous token from logging.

### DIFF
--- a/src/requestAsPromise.js
+++ b/src/requestAsPromise.js
@@ -3,28 +3,29 @@ const logger = require("./logger");
 
 module.exports = options =>
   new Promise((resolve, reject) => {
-    logger.info(`API Request ${options.url}`, options);
+    const logUrl = options.url.split("?")[0];
+    logger.info(`API Request ${logUrl}`, options);
     request(options, (error, response, body) => {
       if (error) {
-        logger.debug(`API Response ${options.url}`, { error });
+        logger.debug(`API Response ${logUrl}`, { error });
         reject(error.toString());
       } else if (
         response &&
         response.statusCode &&
         !response.statusCode.toString().startsWith("2")
       ) {
-        logger.debug(`API Response ${options.url}`, {
+        logger.debug(`API Response ${logUrl}`, {
           statusCode: response.statusCode
         });
         reject(
           new Error(
-            `API request ${options.url} failed with status ${
+            `API request ${logUrl} failed with status ${
               response.statusCode
             }`
           )
         );
       } else {
-        logger.debug(`API Response ${options.url}`, body);
+        logger.debug(`API Response ${logUrl}`, body);
         resolve(body);
       }
     });


### PR DESCRIPTION
Previously, the configFileFromGithubUrlVerifier was logging a stray token like this:

    2020-... INFO API Request https://raw.githubusercontent.com/.../clabot-config/master/.clabot?token=XXXX

Strip query parameters from logs to hide that.